### PR TITLE
fix FH-2772

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 /docs
 /resources/docs
 /docs/*
-node_modules
+/node_modules
 fhc-*
 client/default/archive
 ios/www/*


### PR DESCRIPTION
replaced "node_modules" with "/node_modules" in .gitignore
https://issues.jboss.org/browse/FH-2772