### PR TITLE
RHMAP-7779 explicitely allow gap: routes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -7,7 +7,7 @@
 
     <link rel="stylesheet" href="css/app.css">
     <script src="cordova.js" type="text/javascript"></script>
-    <meta http-equiv="Content-Security-Policy" content="default-src *; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src * gap:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'" />
 </head>
 
 <body>


### PR DESCRIPTION
whitelist `gap:` (Cordova internal API) routes because `*` doesn't include them in iOS 10